### PR TITLE
fix canvas width: move responsibility to CSS

### DIFF
--- a/StyleSheet.css
+++ b/StyleSheet.css
@@ -71,3 +71,7 @@
 #divCanvas {
     display: flex;
 }
+
+#TheCanvas {
+    width: 100%;
+}

--- a/createcanvas.js
+++ b/createcanvas.js
@@ -18,7 +18,6 @@ function loadCanvas(id) {
     var size = window.innerWidth;
 
     canvas.id = "TheCanvas";
-    canvas.width = size;
     canvas.height = (9/16) * size; // ration 16:9
     
     //Defines Canvas Border size


### PR DESCRIPTION
Firefox handles canvas width differently than Chrome. Passing the responsibility to CSS should work for all major browser